### PR TITLE
deqp: Add support for KHR-GL tests

### DIFF
--- a/src/deqp/driver.volt
+++ b/src/deqp/driver.volt
@@ -46,6 +46,8 @@ public:
 
 	regressionFiles: string[];
 
+	testsGL3: string[];
+	testsGL31: string[];
 	testsGLES2: string[];
 	testsGLES3: string[];
 	testsGLES31: string[];
@@ -88,17 +90,25 @@ public:
 		launcher = new Launcher(cast(u32) settings.threads);
 
 		// Organize the tests
+		if (settings.testsGL3.length > 0) {
+			tests := settings.testsGL3;
+			results.suites ~= new KhrSuite(this, settings.ctsBuildDir, settings.tempDir, "3", tests);
+		}
+		if (settings.testsGL31.length > 0) {
+			tests := settings.testsGL31;
+			results.suites ~= new KhrSuite(this, settings.ctsBuildDir, settings.tempDir, "31", tests);
+		}
 		if (settings.testsGLES2.length > 0) {
 			tests := settings.testsGLES2;
-			results.suites ~= new Suite(this, settings.ctsBuildDir, settings.tempDir, "2", tests);
+			results.suites ~= new CtsSuite(this, settings.ctsBuildDir, settings.tempDir, "2", tests);
 		}
 		if (settings.testsGLES3.length > 0) {
 			tests := settings.testsGLES3;
-			results.suites ~= new Suite(this, settings.ctsBuildDir, settings.tempDir, "3", tests);
+			results.suites ~= new CtsSuite(this, settings.ctsBuildDir, settings.tempDir, "3", tests);
 		}
 		if (settings.testsGLES31.length > 0) {
 			tests := settings.testsGLES31;
-			results.suites ~= new Suite(this, settings.ctsBuildDir, settings.tempDir, "31", tests);
+			results.suites ~= new CtsSuite(this, settings.ctsBuildDir, settings.tempDir, "31", tests);
 		}
 
 		// The main body of work.

--- a/src/deqp/tests/parser.volt
+++ b/src/deqp/tests/parser.volt
@@ -33,18 +33,24 @@ fn parseTestFile(s: Settings)
 		lines ~= watt.splitLines(file);
 	}
 
-	g2: StringsSink;
-	g3: StringsSink;
-	g31: StringsSink;
+	gl3: StringsSink;
+	gl31: StringsSink;
+	gles2: StringsSink;
+	gles3: StringsSink;
+	gles31: StringsSink;
 
 	info("\tOrganizing tests.");
 	foreach (line; lines) {
 		if (watt.startsWith(line, "dEQP-GLES2")) {
-			g2.sink(line);
+			gles2.sink(line);
 		} else if (watt.startsWith(line, "dEQP-GLES31")) {
-			g31.sink(line);
+			gles31.sink(line);
 		} else if (watt.startsWith(line, "dEQP-GLES3")) {
-			g3.sink(line);
+			gles3.sink(line);
+		} else if (watt.startsWith(line, "KHR-GL30")) {
+			gl3.sink(line);
+		} else if (watt.startsWith(line, "KHR-GL31")) {
+			gl31.sink(line);
 		} else if (watt.startsWith(line, "#") || line.length == 0) {
 			/* nop */
 		} else {
@@ -52,11 +58,13 @@ fn parseTestFile(s: Settings)
 		}
 	}
 
-	s.testsGLES2 = g2.toArray();
-	s.testsGLES3 = g3.toArray();
-	s.testsGLES31 = g31.toArray();
+	s.testsGL3 = gl3.toArray();
+	s.testsGL31 = gl31.toArray();
+	s.testsGLES2 = gles2.toArray();
+	s.testsGLES3 = gles3.toArray();
+	s.testsGLES31 = gles31.toArray();
 
-	info("\tGot %s tests.", s.testsGLES2.length + s.testsGLES3.length + s.testsGLES31.length);
+	info("\tGot %s tests.", s.testsGL3.length + s.testsGL31.length + s.testsGLES2.length + s.testsGLES3.length + s.testsGLES31.length);
 }
 
 fn parseAndCheckRegressions(suites: Suite[], filenames: string[]) i32
@@ -92,7 +100,9 @@ fn parseAndCheckRegressions(suites: Suite[], filenames: string[]) i32
 		// Loop over all lines not including the JSON header.
 		foreach (line; lines[count .. $]) {
 
-			if (watt.startsWith(line, "dEQP-GLES2") ||
+			if (watt.startsWith(line, "KHR-GL31") ||
+			    watt.startsWith(line, "KHR-GL30") ||
+			    watt.startsWith(line, "dEQP-GLES2") ||
 			    watt.startsWith(line, "dEQP-GLES31") ||
 			    watt.startsWith(line, "dEQP-GLES3")) {
 				/* nop */

--- a/src/deqp/tests/test.volt
+++ b/src/deqp/tests/test.volt
@@ -83,6 +83,7 @@ class Suite
 {
 public:
 	drv: Driver;
+	api: string;
 	suffix: string;
 	command: string;
 	runDir: string;
@@ -93,19 +94,37 @@ public:
 
 	tests: Test[];
 
-
-public:
 	this(drv: Driver, buildDir: string, tempBaseDir: string, suffix: string, tests: string[])
 	{
 		this.drv = drv;
 		this.suffix = suffix;
-		tempDir = new "${tempBaseDir}${sep}GLES${suffix}";
-		command = new "${buildDir}${sep}modules${sep}gles${suffix}${sep}deqp-gles${suffix}";
 		runDir = new "${buildDir}${sep}external${sep}openglcts${sep}modules";
 
 		this.tests = new Test[](tests.length);
 		foreach (i, ref test; this.tests) {
 			test.set(tests[i]);
 		}
+	}
+}
+
+class CtsSuite : Suite
+{
+	this(drv: Driver, buildDir: string, tempBaseDir: string, suffix: string, tests: string[])
+	{
+		super(drv, buildDir, tempBaseDir, suffix, tests);
+		api = "GLES";
+		tempDir = new "${tempBaseDir}${sep}GLES${suffix}";
+		command = new "${buildDir}${sep}modules${sep}gles${suffix}${sep}deqp-gles${suffix}";
+	}
+}
+
+class KhrSuite : Suite
+{
+	this(drv: Driver, buildDir: string, tempBaseDir: string, suffix: string, tests: string[])
+	{
+		super(drv, buildDir, tempBaseDir, suffix, tests);
+		api = "GL";
+		tempDir = new "${tempBaseDir}${sep}GL${suffix}";
+		command = new "${buildDir}${sep}external${sep}openglcts${sep}modules${sep}glcts";
 	}
 }


### PR DESCRIPTION
This add support for using glcts as a backend and enables
KHR-GL3 & KHR-GL31 prefixed tests.